### PR TITLE
Debug assembly load and xaml errors

### DIFF
--- a/.github/workflows/build-dotnet-desktop-pull-request.yml
+++ b/.github/workflows/build-dotnet-desktop-pull-request.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         configuration: [Debug, Release]
 
-    runs-on: windows-2019  # For a list of available runner types, refer to
+    runs-on: windows-2022  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         configuration: [Debug]
 
-    runs-on: windows-2019  # For a list of available runner types, refer to
+    runs-on: windows-2022  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <RootNamespace>Captura</RootNamespace>
@@ -38,7 +38,9 @@
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.0.0" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.0.8" />
-    <PackageReference Include="ModernUI.WPF" Version="1.0.9" />
+    <PackageReference Include="ModernUI.WPF" Version="1.0.9">
+      <PrivateAssets>none</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SamOatesGames.ModernUI.Xceed.Toolkit" Version="1.0.0" />
   </ItemGroup>
   <Target Name="Delete unused libs" AfterTargets="Build">

--- a/src/PostBuild.targets
+++ b/src/PostBuild.targets
@@ -31,7 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <LibFiles Include="$(OutputPath)*.dll" />
+      <LibFiles Include="$(OutputPath)*.dll" Exclude="$(OutputPath)FirstFloor.ModernUI.dll;$(OutputPath)ModernUI.Xceed.Toolkit.dll" />
       <PdbFiles Include="$(OutputPath)*.pdb" />
       <XmlDocFiles Include="$(OutputPath)*.xml" />
     </ItemGroup>


### PR DESCRIPTION
Update GitHub Actions runners to `windows-2022` and fix ModernUI assembly loading issues.

The `PostBuild.targets` script was moving `FirstFloor.ModernUI.dll` and `ModernUI.Xceed.Toolkit.dll` to a `lib` subfolder, which prevented XAML pack URIs from locating the assemblies, leading to `FileNotFoundException` and `XamlParseException`. This PR excludes these specific DLLs from being moved and updates the package reference to ensure proper copying.

---
<a href="https://cursor.com/background-agent?bcId=bc-79d674e6-d741-484b-9eac-e64a60d715fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79d674e6-d741-484b-9eac-e64a60d715fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

