### PR TITLE
Build new release 10.0.0 with ffmpeg updates

### DIFF
--- a/docs/Build.md
+++ b/docs/Build.md
@@ -24,5 +24,5 @@
 
    YouTube credentials are only required if you want to upload to YouTube. See [here](https://developers.google.com/youtube/registering_an_application) for more info.
 
-3. Download FFmpeg from within the app or from https://ffmpeg.zeranoe.com/builds/ or use a custom build.
+3. Download FFmpeg from within the app or from https://www.gyan.dev/ffmpeg/builds/ or use a custom build.
 4. Now, you're good to go. You can build using Visual Studio or the [cake script](Cake.md).


### PR DESCRIPTION
Update FFmpeg download URL in `docs/Build.md` to a reliable mirror.

The previous FFmpeg download URL (`ffmpeg.zeranoe.com`) is defunct. This update points to `gyan.dev`, which is a current and reliable source for FFmpeg builds, ensuring documentation reflects accurate download instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c8f0d22-82a8-47d1-8a77-588936eb43dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c8f0d22-82a8-47d1-8a77-588936eb43dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

