### PR TITLE
Fix missing modernui assembly dependency

### DIFF
--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -38,9 +38,7 @@
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.0.0" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.0.8" />
-    <PackageReference Include="ModernUI.WPF" Version="1.0.9">
-      <PrivateAssets>none</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="ModernUI.WPF" Version="1.0.9" />
     <PackageReference Include="SamOatesGames.ModernUI.Xceed.Toolkit" Version="1.0.0" />
   </ItemGroup>
   <Target Name="Delete unused libs" AfterTargets="Build">


### PR DESCRIPTION
Remove `PrivateAssets="none"` from `ModernUI.WPF` package reference to resolve `FileNotFoundException` at runtime.

The `PrivateAssets` setting was preventing the `FirstFloor.ModernUI.dll` from being copied to the build output, leading to a `System.IO.FileNotFoundException` when the application attempted to load it. Removing this attribute ensures the necessary DLL is included in the release build.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc7ec683-2cba-4901-ae16-04c76afab490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc7ec683-2cba-4901-ae16-04c76afab490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

