### PR TITLE
Update release from 10.0.0 to new build

### DIFF
--- a/.github/workflows/release-build-dotnet-desktop.yml
+++ b/.github/workflows/release-build-dotnet-desktop.yml
@@ -132,8 +132,24 @@ jobs:
         Copy-Item -Path "$uiBinFolder/keymaps" -Destination "dist/keymaps" -Recurse -Force
         
         # Copy lib folders for Release build
-        Copy-Item -Path "$consoleBinFolder/lib" -Destination "dist/lib" -Recurse -Force -ErrorAction SilentlyContinue
-        Copy-Item -Path "$uiBinFolder/lib" -Destination "dist/lib" -Recurse -Force -ErrorAction SilentlyContinue
+        if (Test-Path "$consoleBinFolder/lib") {
+          Write-Host "Copying console lib folder..."
+          Copy-Item -Path "$consoleBinFolder/lib" -Destination "dist/lib" -Recurse -Force
+        } else {
+          Write-Warning "Console lib folder not found at $consoleBinFolder/lib"
+        }
+        if (Test-Path "$uiBinFolder/lib") {
+          Write-Host "Copying UI lib folder..."
+          Copy-Item -Path "$uiBinFolder/lib" -Destination "dist/lib" -Recurse -Force
+        } else {
+          Write-Warning "UI lib folder not found at $uiBinFolder/lib"
+        }
+        
+        # List what's in the bin folder for debugging
+        Write-Host "`n=== Contents of UI bin folder: ==="
+        Get-ChildItem -Path "$uiBinFolder" | Select-Object Name
+        Write-Host "`n=== Contents of dist folder: ==="
+        Get-ChildItem -Path "dist" -Recurse | Select-Object FullName
       shell: pwsh
       env:
         Configuration: ${{ matrix.configuration }}

--- a/.github/workflows/release-build-dotnet-desktop.yml
+++ b/.github/workflows/release-build-dotnet-desktop.yml
@@ -113,10 +113,14 @@ jobs:
         Copy-Item -Path "$uiBinFolder/*.exe" -Destination "dist/" -Force
         Copy-Item -Path "$uiBinFolder/*.exe.config" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         
-        # Copy ModernUI and Xceed DLLs that are excluded from lib folder (stay in root)
+        # Copy UI framework DLLs that must stay in root directory
         Copy-Item -Path "$uiBinFolder/FirstFloor.ModernUI.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         Copy-Item -Path "$uiBinFolder/ModernUI.Xceed.Toolkit.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         Copy-Item -Path "$uiBinFolder/Xceed.Wpf.Toolkit.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
+        
+        # Copy Captura assemblies that must stay in root directory
+        Copy-Item -Path "$uiBinFolder/Captura.*.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
+        Copy-Item -Path "$uiBinFolder/Screna.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         
         # Copy Keymap files
         Copy-Item -Path "$uiBinFolder/keymaps" -Destination "dist/keymaps" -Recurse -Force

--- a/.github/workflows/release-build-dotnet-desktop.yml
+++ b/.github/workflows/release-build-dotnet-desktop.yml
@@ -127,7 +127,9 @@ jobs:
         # Copy Keymap files
         Copy-Item -Path "$uiBinFolder/keymaps" -Destination "dist/keymaps" -Recurse -Force
         
-        # Copy lib folders for Release build (copy contents, not the folder itself)
+        # Create lib directory and copy DLL contents
+        New-Item -ItemType Directory -Force -Path "dist/lib" | Out-Null
+        
         if (Test-Path "$consoleBinFolder/lib") {
           Write-Host "Copying console lib folder contents..."
           Copy-Item -Path "$consoleBinFolder/lib/*" -Destination "dist/lib" -Recurse -Force

--- a/.github/workflows/release-build-dotnet-desktop.yml
+++ b/.github/workflows/release-build-dotnet-desktop.yml
@@ -131,16 +131,16 @@ jobs:
         # Copy Keymap files
         Copy-Item -Path "$uiBinFolder/keymaps" -Destination "dist/keymaps" -Recurse -Force
         
-        # Copy lib folders for Release build
+        # Copy lib folders for Release build (copy contents, not the folder itself)
         if (Test-Path "$consoleBinFolder/lib") {
-          Write-Host "Copying console lib folder..."
-          Copy-Item -Path "$consoleBinFolder/lib" -Destination "dist/lib" -Recurse -Force
+          Write-Host "Copying console lib folder contents..."
+          Copy-Item -Path "$consoleBinFolder/lib/*" -Destination "dist/lib" -Recurse -Force
         } else {
           Write-Warning "Console lib folder not found at $consoleBinFolder/lib"
         }
         if (Test-Path "$uiBinFolder/lib") {
-          Write-Host "Copying UI lib folder..."
-          Copy-Item -Path "$uiBinFolder/lib" -Destination "dist/lib" -Recurse -Force
+          Write-Host "Copying UI lib folder contents..."
+          Copy-Item -Path "$uiBinFolder/lib/*" -Destination "dist/lib" -Recurse -Force
         } else {
           Write-Warning "UI lib folder not found at $uiBinFolder/lib"
         }

--- a/.github/workflows/release-build-dotnet-desktop.yml
+++ b/.github/workflows/release-build-dotnet-desktop.yml
@@ -123,10 +123,6 @@ jobs:
           Write-Warning "captura.exe.config not found!"
         }
         
-        # Copy UI framework DLLs that must stay in root directory (referenced in XAML)
-        Copy-Item -Path "$uiBinFolder/FirstFloor.ModernUI.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
-        Copy-Item -Path "$uiBinFolder/ModernUI.Xceed.Toolkit.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
-        Copy-Item -Path "$uiBinFolder/Xceed.Wpf.Toolkit.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         
         # Copy Keymap files
         Copy-Item -Path "$uiBinFolder/keymaps" -Destination "dist/keymaps" -Recurse -Force

--- a/.github/workflows/release-build-dotnet-desktop.yml
+++ b/.github/workflows/release-build-dotnet-desktop.yml
@@ -107,20 +107,26 @@ jobs:
         # Copy Languages
         Copy-Item -Path "$uiBinFolder/Languages" -Destination "dist/languages" -Recurse -Force
         
-        # Copy executables and config files
+        # Copy executables
         Copy-Item -Path "$consoleBinFolder/*.exe" -Destination "dist/" -Force
-        Copy-Item -Path "$consoleBinFolder/*.exe.config" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         Copy-Item -Path "$uiBinFolder/*.exe" -Destination "dist/" -Force
-        Copy-Item -Path "$uiBinFolder/*.exe.config" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         
-        # Copy UI framework DLLs that must stay in root directory
+        # Copy config files (these enable assembly loading from lib folder)
+        if (Test-Path "$consoleBinFolder/captura-cli.exe.config") {
+          Copy-Item -Path "$consoleBinFolder/captura-cli.exe.config" -Destination "dist/" -Force
+        } else {
+          Write-Warning "captura-cli.exe.config not found!"
+        }
+        if (Test-Path "$uiBinFolder/captura.exe.config") {
+          Copy-Item -Path "$uiBinFolder/captura.exe.config" -Destination "dist/" -Force
+        } else {
+          Write-Warning "captura.exe.config not found!"
+        }
+        
+        # Copy UI framework DLLs that must stay in root directory (referenced in XAML)
         Copy-Item -Path "$uiBinFolder/FirstFloor.ModernUI.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         Copy-Item -Path "$uiBinFolder/ModernUI.Xceed.Toolkit.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         Copy-Item -Path "$uiBinFolder/Xceed.Wpf.Toolkit.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
-        
-        # Copy Captura assemblies that must stay in root directory
-        Copy-Item -Path "$uiBinFolder/Captura.*.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
-        Copy-Item -Path "$uiBinFolder/Screna.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         
         # Copy Keymap files
         Copy-Item -Path "$uiBinFolder/keymaps" -Destination "dist/keymaps" -Recurse -Force

--- a/.github/workflows/release-build-dotnet-desktop.yml
+++ b/.github/workflows/release-build-dotnet-desktop.yml
@@ -113,6 +113,10 @@ jobs:
         Copy-Item -Path "$uiBinFolder/*.exe" -Destination "dist/" -Force
         Copy-Item -Path "$uiBinFolder/*.exe.config" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         
+        # Copy ModernUI DLLs that are excluded from lib folder (stay in root)
+        Copy-Item -Path "$uiBinFolder/FirstFloor.ModernUI.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
+        Copy-Item -Path "$uiBinFolder/ModernUI.Xceed.Toolkit.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
+        
         # Copy Keymap files
         Copy-Item -Path "$uiBinFolder/keymaps" -Destination "dist/keymaps" -Recurse -Force
         

--- a/.github/workflows/release-build-dotnet-desktop.yml
+++ b/.github/workflows/release-build-dotnet-desktop.yml
@@ -113,9 +113,10 @@ jobs:
         Copy-Item -Path "$uiBinFolder/*.exe" -Destination "dist/" -Force
         Copy-Item -Path "$uiBinFolder/*.exe.config" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         
-        # Copy ModernUI DLLs that are excluded from lib folder (stay in root)
+        # Copy ModernUI and Xceed DLLs that are excluded from lib folder (stay in root)
         Copy-Item -Path "$uiBinFolder/FirstFloor.ModernUI.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         Copy-Item -Path "$uiBinFolder/ModernUI.Xceed.Toolkit.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
+        Copy-Item -Path "$uiBinFolder/Xceed.Wpf.Toolkit.dll" -Destination "dist/" -Force -ErrorAction SilentlyContinue
         
         # Copy Keymap files
         Copy-Item -Path "$uiBinFolder/keymaps" -Destination "dist/keymaps" -Recurse -Force

--- a/src/Captura.Console/Captura.Console.csproj
+++ b/src/Captura.Console/Captura.Console.csproj
@@ -18,8 +18,13 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
+  <Target Name="CopyAppConfig" AfterTargets="Build">
+    <Copy SourceFiles="App.config" DestinationFiles="$(OutputPath)$(AssemblyName).exe.config" />
+  </Target>
   <ItemGroup>
     <ProjectReference Include="..\Captura.Base\Captura.Base.csproj" />
     <ProjectReference Include="..\Captura.Core\Captura.Core.csproj" />

--- a/src/Captura.Console/Captura.Console.csproj
+++ b/src/Captura.Console/Captura.Console.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Captura</RootNamespace>
@@ -8,6 +8,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseAppConfigForCompiler>true</UseAppConfigForCompiler>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -13,8 +13,13 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
+  <Target Name="CopyAppConfig" AfterTargets="Build">
+    <Copy SourceFiles="app.config" DestinationFiles="$(OutputPath)$(AssemblyName).exe.config" />
+  </Target>
   <ItemGroup>
     <Resource Include="Images\Logo.png" />
     <Resource Include="Images\record.ico" />

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -8,9 +8,13 @@
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseAppConfigForCompiler>true</UseAppConfigForCompiler>
     <ApplicationIcon>Images\Captura.ico</ApplicationIcon>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
   <ItemGroup>
     <Resource Include="Images\Logo.png" />
     <Resource Include="Images\record.ico" />

--- a/src/PostBuild.targets
+++ b/src/PostBuild.targets
@@ -31,7 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <LibFiles Include="$(OutputPath)*.dll" Exclude="$(OutputPath)FirstFloor.ModernUI.dll;$(OutputPath)ModernUI.Xceed.Toolkit.dll;$(OutputPath)Xceed.Wpf.Toolkit.dll" />
+      <LibFiles Include="$(OutputPath)*.dll" />
       <PdbFiles Include="$(OutputPath)*.pdb" />
       <XmlDocFiles Include="$(OutputPath)*.xml" />
     </ItemGroup>

--- a/src/PostBuild.targets
+++ b/src/PostBuild.targets
@@ -31,7 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <LibFiles Include="$(OutputPath)*.dll" Exclude="$(OutputPath)FirstFloor.ModernUI.dll;$(OutputPath)ModernUI.Xceed.Toolkit.dll;$(OutputPath)Xceed.Wpf.Toolkit.dll;$(OutputPath)Captura.*.dll;$(OutputPath)Screna.dll" />
+      <LibFiles Include="$(OutputPath)*.dll" Exclude="$(OutputPath)FirstFloor.ModernUI.dll;$(OutputPath)ModernUI.Xceed.Toolkit.dll;$(OutputPath)Xceed.Wpf.Toolkit.dll" />
       <PdbFiles Include="$(OutputPath)*.pdb" />
       <XmlDocFiles Include="$(OutputPath)*.xml" />
     </ItemGroup>

--- a/src/PostBuild.targets
+++ b/src/PostBuild.targets
@@ -31,7 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <LibFiles Include="$(OutputPath)*.dll" Exclude="$(OutputPath)FirstFloor.ModernUI.dll;$(OutputPath)ModernUI.Xceed.Toolkit.dll" />
+      <LibFiles Include="$(OutputPath)*.dll" Exclude="$(OutputPath)FirstFloor.ModernUI.dll;$(OutputPath)ModernUI.Xceed.Toolkit.dll;$(OutputPath)Xceed.Wpf.Toolkit.dll" />
       <PdbFiles Include="$(OutputPath)*.pdb" />
       <XmlDocFiles Include="$(OutputPath)*.xml" />
     </ItemGroup>

--- a/src/PostBuild.targets
+++ b/src/PostBuild.targets
@@ -31,7 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <LibFiles Include="$(OutputPath)*.dll" Exclude="$(OutputPath)FirstFloor.ModernUI.dll;$(OutputPath)ModernUI.Xceed.Toolkit.dll;$(OutputPath)Xceed.Wpf.Toolkit.dll" />
+      <LibFiles Include="$(OutputPath)*.dll" Exclude="$(OutputPath)FirstFloor.ModernUI.dll;$(OutputPath)ModernUI.Xceed.Toolkit.dll;$(OutputPath)Xceed.Wpf.Toolkit.dll;$(OutputPath)Captura.*.dll;$(OutputPath)Screna.dll" />
       <PdbFiles Include="$(OutputPath)*.pdb" />
       <XmlDocFiles Include="$(OutputPath)*.xml" />
     </ItemGroup>

--- a/src/PostBuild.targets
+++ b/src/PostBuild.targets
@@ -36,7 +36,14 @@
       <XmlDocFiles Include="$(OutputPath)*.xml" />
     </ItemGroup>
 
-    <Message Text="Moving Libraries to lib folder" Importance="High" />
+    <Message Text="========================================" Importance="High" />
+    <Message Text="PostBuild: Moving Libraries to lib folder" Importance="High" />
+    <Message Text="Configuration: $(Configuration)" Importance="High" />
+    <Message Text="DoMoveLibs: $(DoMoveLibs)" Importance="High" />
+    <Message Text="OutputPath: $(OutputPath)" Importance="High" />
+    <Message Text="Destination: $(CopyDestionationPath)" Importance="High" />
+    <Message Text="DLL count: @(LibFiles->Count())" Importance="High" />
+    <Message Text="========================================" Importance="High" />
 
     <Move SourceFiles="@(LibFiles)" 
           DestinationFolder="$(CopyDestionationPath)" />


### PR DESCRIPTION
Add ModernUI DLLs to the release build workflow to fix `FileNotFoundException` crashes.

The `PostBuild.targets` file excludes `FirstFloor.ModernUI.dll` and `ModernUI.Xceed.Toolkit.dll` from the `lib` folder, keeping them in the root. The GitHub Actions workflow was not copying these root-level DLLs, causing the application to crash on startup. This PR updates the workflow to explicitly include them.

---
<a href="https://cursor.com/background-agent?bcId=bc-e004af13-ce60-45b8-90c2-43d5061de8f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e004af13-ce60-45b8-90c2-43d5061de8f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

