### PR TITLE
Research mf codec hardware support apis

### DIFF
--- a/docs/Cmdline/README.md
+++ b/docs/Cmdline/README.md
@@ -45,6 +45,8 @@ captura --tray
   Take a ScreenShot
 - [ffmpeg](Verb-FFmpeg.md)  
   Allows installation of ffmpeg from command-line.
+- [mf-hw](Verb-MfHw.md)
+  Print Media Foundation hardware codec support (Windows only)
 - help  
   Provides help on using the console app.
 - version  

--- a/docs/Cmdline/Verb-MfHw.md
+++ b/docs/Cmdline/Verb-MfHw.md
@@ -1,0 +1,29 @@
+# Verb: mf-hw
+
+Print Media Foundation hardware codec support matrix as JSON.
+
+Example:
+
+```bash
+captura-cli mf-hw
+```
+
+Sample output:
+
+```json
+{
+  "GpuName": "NVIDIA GeForce RTX 3080",
+  "Codecs": [
+    {
+      "Codec": "H264",
+      "Encoder": { "HardwarePresent": true, "AcceptsNV12": true, "AcceptsP010": false },
+      "Decoder": { "HardwarePresent": true, "OutputsNV12": true, "OutputsP010": false }
+    },
+    {
+      "Codec": "HEVC",
+      "Encoder": { "HardwarePresent": true, "AcceptsNV12": true, "AcceptsP010": true },
+      "Decoder": { "HardwarePresent": true, "OutputsNV12": true, "OutputsP010": true }
+    }
+  ]
+}
+```

--- a/src/Captura.Console/Captura.Console.csproj
+++ b/src/Captura.Console/Captura.Console.csproj
@@ -18,6 +18,9 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Captura.Windows\Captura.Windows.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="App.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -42,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <Import Project="../PostBuild.targets" />
 </Project>

--- a/src/Captura.Console/CmdOptions/HwMfCmdOptions.cs
+++ b/src/Captura.Console/CmdOptions/HwMfCmdOptions.cs
@@ -1,0 +1,18 @@
+using CommandLine;
+using Captura.Windows.MediaFoundation;
+using Newtonsoft.Json;
+using static System.Console;
+
+namespace Captura
+{
+    [Verb("mf-hw", HelpText = "Print Media Foundation hardware codec support as JSON.")]
+    class HwMfCmdOptions : ICmdlineVerb
+    {
+        public void Run()
+        {
+            var matrix = MfHardwareProbe.Probe();
+            var json = JsonConvert.SerializeObject(matrix, Formatting.Indented);
+            WriteLine(json);
+        }
+    }
+}

--- a/src/Captura.Console/CmdOptions/VerbsModule.cs
+++ b/src/Captura.Console/CmdOptions/VerbsModule.cs
@@ -1,4 +1,4 @@
-﻿namespace Captura
+namespace Captura
 {
     class VerbsModule : IModule
     {
@@ -12,6 +12,7 @@
             Binder.Bind<ICmdlineVerb, ShotCmdOptions>();
             Binder.Bind<ICmdlineVerb, FFmpegCmdOptions>();
             Binder.Bind<ICmdlineVerb, ListCmdOptions>();
+            Binder.Bind<ICmdlineVerb, HwMfCmdOptions>();
             Binder.Bind<ICmdlineVerb, UploadCmdOptions>();
         }
     }

--- a/src/Captura.Windows/MediaFoundation/MfHardwareProbe.cs
+++ b/src/Captura.Windows/MediaFoundation/MfHardwareProbe.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SharpDX.Direct3D;
+using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using SharpDX.MediaFoundation;
+using MediaFoundation.Transform;
+using Device = SharpDX.Direct3D11.Device;
+
+namespace Captura.Windows.MediaFoundation
+{
+    public static class MfHardwareProbe
+    {
+        public class MfSupportMatrix
+        {
+            public string GpuName { get; set; }
+            public List<MfCodecInfo> Codecs { get; set; } = new List<MfCodecInfo>();
+        }
+
+        public class MfCodecInfo
+        {
+            public string Codec { get; set; }
+            public MfEncoderInfo Encoder { get; set; } = new MfEncoderInfo();
+            public MfDecoderInfo Decoder { get; set; } = new MfDecoderInfo();
+        }
+
+        public class MfEncoderInfo
+        {
+            public bool HardwarePresent { get; set; }
+            public bool AcceptsNV12 { get; set; }
+            public bool AcceptsP010 { get; set; }
+        }
+
+        public class MfDecoderInfo
+        {
+            public bool HardwarePresent { get; set; }
+            public bool OutputsNV12 { get; set; }
+            public bool OutputsP010 { get; set; }
+        }
+
+        static readonly Guid VideoFormatP010 = new Guid("30313050-0000-0010-8000-00AA00389B71");
+        static readonly Guid Vp9EncodedGuid = new Guid("A3DF5476-2858-4B1D-B9DC-0FC9E7F4F3F5");
+
+        public static MfSupportMatrix Probe()
+        {
+            // Ensure MF is ready
+            MfManager.Startup();
+
+            var matrix = new MfSupportMatrix
+            {
+                GpuName = GetGpuName()
+            };
+
+            using var device = new Device(DriverType.Hardware, DeviceCreationFlags.BgraSupport);
+            using var dxgiManager = new DXGIDeviceManager();
+            dxgiManager.ResetDevice(device);
+
+            var codecs = new List<(string Name, Guid EncodedGuid)>
+            {
+                ("H264", VideoFormatGuids.H264),
+                ("HEVC", VideoFormatGuids.Hevc),
+                ("VP9", Vp9EncodedGuid)
+            };
+
+            foreach (var (name, encodedGuid) in codecs)
+            {
+                var info = new MfCodecInfo { Codec = name };
+
+                // Encoders
+                var encoderActivates = MediaFactory.FindTransform(
+                    TransformCategoryGuids.VideoEncoder,
+                    TransformEnumFlag.Hardware);
+
+                info.Encoder.HardwarePresent = false;
+                info.Encoder.AcceptsNV12 = false;
+                info.Encoder.AcceptsP010 = false;
+
+                foreach (var activate in encoderActivates)
+                {
+                    try
+                    {
+                        using var transform = activate.ActivateObject<Transform>();
+                        transform.ProcessMessage(TMessageType.SetD3DManager, dxgiManager.NativePointer);
+
+                        if (!info.Encoder.HardwarePresent && TryConfigureEncoder(transform, encodedGuid, VideoFormatGuids.NV12))
+                            info.Encoder.HardwarePresent = true;
+
+                        if (TryConfigureEncoder(transform, encodedGuid, VideoFormatGuids.NV12))
+                            info.Encoder.AcceptsNV12 = true;
+
+                        if (TryConfigureEncoder(transform, encodedGuid, VideoFormatP010))
+                            info.Encoder.AcceptsP010 = true;
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                    finally
+                    {
+                        activate.Dispose();
+                    }
+                }
+
+                // Decoders
+                var decoderActivates = MediaFactory.FindTransform(
+                    TransformCategoryGuids.VideoDecoder,
+                    TransformEnumFlag.Hardware);
+
+                info.Decoder.HardwarePresent = false;
+                info.Decoder.OutputsNV12 = false;
+                info.Decoder.OutputsP010 = false;
+
+                foreach (var activate in decoderActivates)
+                {
+                    try
+                    {
+                        using var transform = activate.ActivateObject<Transform>();
+                        transform.ProcessMessage(TMessageType.SetD3DManager, dxgiManager.NativePointer);
+
+                        if (!info.Decoder.HardwarePresent && TryConfigureDecoder(transform, encodedGuid, VideoFormatGuids.NV12))
+                            info.Decoder.HardwarePresent = true;
+
+                        if (TryConfigureDecoder(transform, encodedGuid, VideoFormatGuids.NV12))
+                            info.Decoder.OutputsNV12 = true;
+
+                        if (TryConfigureDecoder(transform, encodedGuid, VideoFormatP010))
+                            info.Decoder.OutputsP010 = true;
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                    finally
+                    {
+                        activate.Dispose();
+                    }
+                }
+
+                matrix.Codecs.Add(info);
+            }
+
+            return matrix;
+        }
+
+        static bool TryConfigureEncoder(Transform transform, Guid encodedSubtype, Guid inputPixelFormat)
+        {
+            const int width = 1920;
+            const int height = 1080;
+            const int fps = 30;
+
+            using var mediaTypeIn = new MediaType();
+            mediaTypeIn.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+            mediaTypeIn.Set(MediaTypeAttributeKeys.Subtype, inputPixelFormat);
+            mediaTypeIn.Set(MediaTypeAttributeKeys.FrameSize, PackLong(width, height));
+            mediaTypeIn.Set(MediaTypeAttributeKeys.FrameRate, PackLong(fps, 1));
+            mediaTypeIn.Set(MediaTypeAttributeKeys.PixelAspectRatio, PackLong(1, 1));
+
+            using var mediaTypeOut = new MediaType();
+            mediaTypeOut.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+            mediaTypeOut.Set(MediaTypeAttributeKeys.Subtype, encodedSubtype);
+            mediaTypeOut.Set(MediaTypeAttributeKeys.FrameSize, PackLong(width, height));
+            mediaTypeOut.Set(MediaTypeAttributeKeys.FrameRate, PackLong(fps, 1));
+            mediaTypeOut.Set(MediaTypeAttributeKeys.PixelAspectRatio, PackLong(1, 1));
+
+            try
+            {
+                transform.SetInputType(0, mediaTypeIn, 0);
+                transform.SetOutputType(0, mediaTypeOut, 0);
+                return true;
+            }
+            catch
+            {
+                try
+                {
+                    transform.SetOutputType(0, mediaTypeOut, 0);
+                    transform.SetInputType(0, mediaTypeIn, 0);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
+        static bool TryConfigureDecoder(Transform transform, Guid encodedSubtype, Guid outputPixelFormat)
+        {
+            const int width = 1920;
+            const int height = 1080;
+            const int fps = 30;
+
+            using var mediaTypeIn = new MediaType();
+            mediaTypeIn.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+            mediaTypeIn.Set(MediaTypeAttributeKeys.Subtype, encodedSubtype);
+            mediaTypeIn.Set(MediaTypeAttributeKeys.FrameSize, PackLong(width, height));
+            mediaTypeIn.Set(MediaTypeAttributeKeys.FrameRate, PackLong(fps, 1));
+            mediaTypeIn.Set(MediaTypeAttributeKeys.PixelAspectRatio, PackLong(1, 1));
+
+            using var mediaTypeOut = new MediaType();
+            mediaTypeOut.Set(MediaTypeAttributeKeys.MajorType, MediaTypeGuids.Video);
+            mediaTypeOut.Set(MediaTypeAttributeKeys.Subtype, outputPixelFormat);
+            mediaTypeOut.Set(MediaTypeAttributeKeys.FrameSize, PackLong(width, height));
+            mediaTypeOut.Set(MediaTypeAttributeKeys.FrameRate, PackLong(fps, 1));
+            mediaTypeOut.Set(MediaTypeAttributeKeys.PixelAspectRatio, PackLong(1, 1));
+
+            try
+            {
+                transform.SetInputType(0, mediaTypeIn, 0);
+                transform.SetOutputType(0, mediaTypeOut, 0);
+                return true;
+            }
+            catch
+            {
+                try
+                {
+                    transform.SetOutputType(0, mediaTypeOut, 0);
+                    transform.SetInputType(0, mediaTypeIn, 0);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
+        static long PackLong(int left, int right)
+        {
+            return ((long)left << 32) | (uint)right;
+        }
+
+        static string GetGpuName()
+        {
+            try
+            {
+                using var factory = new Factory1();
+                var adapter = factory.Adapters1.FirstOrDefault();
+                return adapter?.Description.Description ?? string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a helper function to query Media Foundation (MF) codec hardware support.

To consolidate disparate APIs into a single, reliable method for determining hardware acceleration capabilities for video codecs.

---
<a href="https://cursor.com/background-agent?bcId=bc-80a0c0d4-f6aa-4360-9ca1-023b366c1715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80a0c0d4-f6aa-4360-9ca1-023b366c1715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

