### PR TITLE
Implement hardware encoding acceleration inspired by OBS

### DIFF
--- a/docs/FFmpeg.md
+++ b/docs/FFmpeg.md
@@ -5,6 +5,23 @@
 [FFmpeg](http://ffmpeg.org/) is an open-source cross-platform solution to record, convert and stream audio and video.
 It adds support for more output formats like **H.264** for Video and **Mp3**, **AAC** etc. when capturing **Only Audio**.
 
+## Hardware Encoding Support
+
+Captura supports hardware-accelerated encoding through FFmpeg, which significantly improves performance and reduces CPU usage:
+
+- **AMD GPUs**: AMD Advanced Media Framework (AMF) - Supports H.264, HEVC (H.265), and AV1
+  - Inspired by OBS Studio's AMD hardware encoding implementation
+  - Requires AMD Radeon HD 7000 series or newer, or APU with GCN architecture
+  - Ensure your AMD drivers are up to date for best performance
+
+- **NVIDIA GPUs**: NVENC - Supports H.264 and HEVC (H.265)
+  - Check NVIDIA's website to verify your GPU supports NVENC
+
+- **Intel CPUs**: Intel QuickSync (QSV) - Supports HEVC (H.265)
+  - Requires Skylake generation or later processor with integrated graphics
+
+Hardware encoding offloads the video encoding work to your GPU, allowing for smoother captures and better performance, especially at higher resolutions and frame rates.
+
 FFmpeg is configured on the **FFmpeg** section in the **Configure** tab.
 
 Due to its large size (approx. 30MB), it is not included in the downloads.

--- a/src/Captura.FFmpeg/Video/Codecs/AmfVideoCodec.cs
+++ b/src/Captura.FFmpeg/Video/Codecs/AmfVideoCodec.cs
@@ -1,0 +1,93 @@
+using Captura.Video;
+
+namespace Captura.FFmpeg
+{
+    /// <summary>
+    /// AMD Advanced Media Framework (AMF) hardware encoder support.
+    /// Inspired by OBS Studio's implementation of AMD hardware encoding.
+    /// </summary>
+    class AmfVideoCodec : FFmpegVideoCodec
+    {
+        readonly string _fFmpegCodecName;
+
+        const string AmfSupport = "Requires AMD GPU with AMF support (Radeon HD 7000 series or newer, or APU with GCN architecture).\n" +
+                                  "Inspired by OBS Studio's AMD hardware encoding implementation.\n" +
+                                  "If this doesn't work, ensure your AMD drivers are up to date and AMF is supported by your GPU.";
+
+        AmfVideoCodec(string Name, string FFmpegCodecName, string Description)
+            : base(Name, ".mp4", $"{Description}\n{AmfSupport}")
+        {
+            _fFmpegCodecName = FFmpegCodecName;
+        }
+
+        public override FFmpegAudioArgsProvider AudioArgsProvider => FFmpegAudioItem.Aac;
+
+        public override void Apply(FFmpegSettings Settings, VideoWriterArgs WriterArgs, FFmpegOutputArgs OutputArgs)
+        {
+            // AMF encoder settings inspired by OBS Studio's implementation
+            // Using quality-balanced presets that work well for screen recording
+            OutputArgs.AddArg("c:v", _fFmpegCodecName)
+                .AddArg("quality", "balanced")           // Quality preset: speed, balanced, or quality
+                .AddArg("rc", "vbr_latency")             // Rate control: VBR with low latency (good for recording)
+                .AddArg("usage", "ultralowlatency")      // Usage mode optimized for ultra low latency
+                .AddArg("profile:v", "high")             // Use high profile for better quality
+                .AddArg("level", "auto");                // Auto-detect appropriate level
+            
+            // Preset mapping (similar to OBS):
+            // - speed: fastest encoding, lower quality
+            // - balanced: good balance between speed and quality
+            // - quality: best quality, slower encoding
+            // For screen recording, balanced is a good default
+            OutputArgs.AddArg("preset", "balanced");
+            
+            // Optional: Enable pre-analysis for better quality (like OBS does)
+            // This can improve quality at minimal performance cost
+            OutputArgs.AddArg("preanalysis", "true");
+            
+            // Set GOP size for better seeking and compatibility
+            // 250 is a good default for 60fps content (about 4 seconds)
+            OutputArgs.AddArg("g", "250");
+            
+            // Optional: Set bitrate if specified in settings
+            // AMF works best with VBR, so we set target bitrate
+            // OutputArgs.AddArg("b:v", "5M");           // Can be customized based on user settings
+        }
+
+        /// <summary>
+        /// Create H.264 AMF encoder instance.
+        /// H.264/AVC is widely supported and provides excellent compatibility.
+        /// </summary>
+        public static AmfVideoCodec CreateH264()
+        {
+            return new AmfVideoCodec(
+                "AMD AMF: Mp4 (H.264, AAC)", 
+                "h264_amf", 
+                "Encode to Mp4: H.264 with AAC audio using AMD Advanced Media Framework (AMF) hardware encoding");
+        }
+
+        /// <summary>
+        /// Create HEVC/H.265 AMF encoder instance.
+        /// HEVC provides better compression but requires more modern hardware.
+        /// </summary>
+        public static AmfVideoCodec CreateHevc()
+        {
+            return new AmfVideoCodec(
+                "AMD AMF: Mp4 (HEVC, AAC)", 
+                "hevc_amf", 
+                "Encode to Mp4: HEVC (H.265) with AAC audio using AMD Advanced Media Framework (AMF) hardware encoding");
+        }
+
+        /// <summary>
+        /// Create AV1 AMF encoder instance.
+        /// AV1 is the newest codec with best compression, but requires latest AMD GPUs (RDNA 2+).
+        /// </summary>
+        public static AmfVideoCodec CreateAv1()
+        {
+            return new AmfVideoCodec(
+                "AMD AMF: Mp4 (AV1, AAC)", 
+                "av1_amf", 
+                "Encode to Mp4: AV1 with AAC audio using AMD Advanced Media Framework (AMF) hardware encoding.\n" +
+                "Requires AMD RDNA 2 or newer (RX 6000 series or later)");
+        }
+    }
+}

--- a/src/Captura.FFmpeg/Video/FFmpegWriterProvider.cs
+++ b/src/Captura.FFmpeg/Video/FFmpegWriterProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -23,8 +23,16 @@ namespace Captura.FFmpeg
             yield return new X264VideoCodec();
             yield return new XvidVideoCodec();
 
-            // Hardware
+            // Hardware encoders
+            // AMD AMF (inspired by OBS Studio)
+            yield return AmfVideoCodec.CreateH264();
+            yield return AmfVideoCodec.CreateHevc();
+            yield return AmfVideoCodec.CreateAv1();
+            
+            // Intel QuickSync
             yield return new QsvHevcVideoCodec();
+            
+            // NVIDIA NVENC
             yield return NvencVideoCodec.CreateH264();
             yield return NvencVideoCodec.CreateHevc();
 


### PR DESCRIPTION
Add AMD AMF hardware encoding support, inspired by OBS Studio, to improve performance on AMD GPUs.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c43a6ca-15b7-4255-9aae-29dfba516278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c43a6ca-15b7-4255-9aae-29dfba516278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

