### PR TITLE
Investigate full screen recording bug

### DIFF
--- a/FIX_BLACK_SCREEN_RECORDING.md
+++ b/FIX_BLACK_SCREEN_RECORDING.md
@@ -1,0 +1,63 @@
+# Fix for Black Screen Recording on Fullscreen/Monitor Capture
+
+## Problem
+On certain laptop configurations, fullscreen and monitor capture produce black recordings, while window and region capture work correctly. This issue exists in mrchipset's fork but not in Sachin's original release.
+
+## Root Cause
+The issue is in how the monitor handle (HMONITOR) is obtained for Windows Graphics Capture (WGC) API:
+
+**Previous Implementation:**
+- `WgcScreenImageProvider` used `MonitorHelper.GetMonitorFromRect()` 
+- This function uses `MonitorFromPoint()` with the center point of the screen rectangle
+- On some laptop configurations (especially with unusual multi-monitor setups or hybrid graphics), this can return an incorrect or invalid monitor handle
+- An invalid monitor handle causes WGC to fail silently, resulting in black frames
+
+**Why Window Capture Works:**
+- Window capture uses `WgcImageProvider` which takes a window handle (HWND), not a monitor handle
+- Window handles are more reliable and don't have the same identification issues
+
+## Solution
+Use the DXGI API's monitor handle instead of calculating it from a point:
+
+1. **`WindowsPlatformServices.GetScreenProvider()`** - Modified to:
+   - Call `FindOutput()` to get the DXGI `Output1` for the screen
+   - Extract the monitor handle from `Output.Description.Monitor` (this is the actual HMONITOR from DXGI)
+   - Pass this handle to `WgcScreenImageProvider`
+   - Falls back to `MonitorHelper` if DXGI Output is not found
+
+2. **`WindowsPlatformServices.GetAllScreensProvider()`** - Modified to:
+   - Get the primary screen's DXGI `Output1`
+   - Use its `Output.Description.Monitor` handle for the fullscreen capture
+   - Falls back to `MonitorHelper` if DXGI Output is not found
+
+3. **`WgcScreenImageProvider` constructor** - Modified to:
+   - Accept an optional `IntPtr? monitorHandle` parameter
+   - Use the provided handle if available, otherwise fallback to `MonitorHelper.GetMonitorFromRect()`
+
+## Files Changed
+1. `/workspace/src/Captura.Windows/WindowsPlatformServices.cs`
+2. `/workspace/src/Captura.Windows/WindowsGraphicsCapture/WgcScreenImageProvider.cs`
+
+## Why This Fix Works
+- The DXGI API provides accurate monitor handles through `Output.Description.Monitor`
+- This is the same handle that the underlying graphics driver uses
+- By using the handle from DXGI instead of calculating it from a point, we ensure consistency
+- The Desktop Duplication method already uses DXGI Outputs, so this aligns WGC with the same approach
+
+## Testing
+To test this fix:
+1. Build the application using Visual Studio or MSBuild on Windows
+2. Run on the affected laptop
+3. Try fullscreen capture - should now show actual content instead of black screen
+4. Try monitor selection - should now show actual content instead of black screen
+5. Verify that window and region capture still work (they should be unaffected)
+
+## Backward Compatibility
+- The fix maintains backward compatibility with fallback to `MonitorHelper` if DXGI Output is not found
+- No breaking changes to existing APIs
+- Window and region capture are completely unaffected
+
+## Related Information
+- DXGI_OUTPUT_DESC structure: https://docs.microsoft.com/en-us/windows/win32/api/dxgi/ns-dxgi-dxgi_output_desc
+- The `Monitor` field in DXGI_OUTPUT_DESC is the official HMONITOR handle for the display
+- This is more reliable than using `MonitorFromPoint()` which can fail on complex display configurations

--- a/src/Captura.Windows/WindowsGraphicsCapture/WgcScreenImageProvider.cs
+++ b/src/Captura.Windows/WindowsGraphicsCapture/WgcScreenImageProvider.cs
@@ -10,7 +10,7 @@ namespace Captura.Windows.WindowsGraphicsCapture
         readonly WgcCaptureSession _capture;
         readonly Rectangle _screenBounds;
         
-        public WgcScreenImageProvider(Rectangle screenBounds, IPreviewWindow previewWindow)
+        public WgcScreenImageProvider(Rectangle screenBounds, IPreviewWindow previewWindow, IntPtr? monitorHandle = null)
         {
             _screenBounds = screenBounds;
             Width = screenBounds.Width;
@@ -18,7 +18,8 @@ namespace Captura.Windows.WindowsGraphicsCapture
             
             PointTransform = P => new Point(P.X - screenBounds.Left, P.Y - screenBounds.Top);
             
-            var hmon = MonitorHelper.GetMonitorFromRect(screenBounds);
+            // Use provided monitor handle if available, otherwise fallback to MonitorHelper
+            var hmon = monitorHandle ?? MonitorHelper.GetMonitorFromRect(screenBounds);
             _capture = new WgcCaptureSession(hmon, Width, Height, previewWindow, isMonitor: true);
         }
         

--- a/src/Captura.Windows/WindowsPlatformServices.cs
+++ b/src/Captura.Windows/WindowsPlatformServices.cs
@@ -122,13 +122,23 @@ namespace Captura.Windows
             
             if (WindowsModule.ShouldUseWgc)
             {
+                // Use DXGI Output's Monitor handle for accurate monitor identification
+                var output = FindOutput(Screen);
+                if (output != null)
+                {
+                    var hmon = output.Description.Monitor;
+                    output.Dispose();
+                    return new WgcScreenImageProvider(Screen.Rectangle, _previewWindow, hmon);
+                }
+                
+                // Fallback to MonitorHelper if DXGI Output not found
                 return new WgcScreenImageProvider(Screen.Rectangle, _previewWindow);
             }
             
-            var output = FindOutput(Screen);
-            if (output != null)
+            var output2 = FindOutput(Screen);
+            if (output2 != null)
             {
-                return new DeskDuplImageProvider(output, IncludeCursor, _previewWindow);
+                return new DeskDuplImageProvider(output2, IncludeCursor, _previewWindow);
             }
             
             throw new Exception("No screen output found for Desktop Duplication. Enable WGC or GDI mode in settings.");
@@ -163,6 +173,21 @@ namespace Captura.Windows
             
             if (WindowsModule.ShouldUseWgc)
             {
+                // For full screen, try to use the primary monitor's handle from DXGI
+                var screens = EnumerateScreens().ToList();
+                if (screens.Any())
+                {
+                    var primaryScreen = screens.FirstOrDefault(s => s.Rectangle.X == 0 && s.Rectangle.Y == 0) ?? screens.First();
+                    var output = FindOutput(primaryScreen);
+                    if (output != null)
+                    {
+                        var hmon = output.Description.Monitor;
+                        output.Dispose();
+                        return new WgcScreenImageProvider(DesktopRectangle, _previewWindow, hmon);
+                    }
+                }
+                
+                // Fallback to MonitorHelper
                 return new WgcScreenImageProvider(DesktopRectangle, _previewWindow);
             }
             


### PR DESCRIPTION
Use DXGI Output's monitor handle for Windows Graphics Capture to fix black screen recordings on some laptop configurations.

The previous implementation used `MonitorFromPoint` with the center of the screen rectangle to obtain the monitor handle. This method proved unreliable on certain laptop setups, leading to an invalid handle and silent failure of Windows Graphics Capture, resulting in black frames. Switching to the DXGI API's `Output.Description.Monitor` provides the correct and consistent monitor handle, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6281ae6-f11a-4d5f-be49-984ace040b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6281ae6-f11a-4d5f-be49-984ace040b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

