### PR TITLE
Fix screen recording bug on devices

### DIFF
--- a/src/Captura.Windows/DesktopDuplication/DesktopDuplicator.cs
+++ b/src/Captura.Windows/DesktopDuplication/DesktopDuplicator.cs
@@ -1,4 +1,4 @@
-﻿// Adapted from https://github.com/jasonpang/desktop-duplication-net
+// Adapted from https://github.com/jasonpang/desktop-duplication-net
 
 using SharpDX.DXGI;
 using System;
@@ -15,7 +15,7 @@ namespace Captura.Windows.DesktopDuplication
 
         public DesktopDuplicator(bool IncludeCursor, Output1 Output, IPreviewWindow PreviewWindow)
         {
-            _duplCapture = new DuplCapture(Output);
+            _duplCapture = new DuplCapture(Output, _editorSession.Device);
 
             var bounds = Output.Description.DesktopBounds;
             var width = bounds.Right - bounds.Left;

--- a/src/Captura.Windows/DesktopDuplication/DuplCapture.cs
+++ b/src/Captura.Windows/DesktopDuplication/DuplCapture.cs
@@ -18,12 +18,10 @@ namespace Captura.Windows.DesktopDuplication
 
         readonly object _syncLock = new object();
 
-        public DuplCapture(Output1 Output)
+        public DuplCapture(Output1 Output, Device device)
         {
-            // Separate Device required otherwise AccessViolationException happens
-            using (var adapter = Output.GetParent<Adapter>())
-                _device = new Device(adapter);
-
+            // Use the provided device (shared with the editor session) so all textures live on the same device
+            _device = device ?? throw new ArgumentNullException(nameof(device));
             _output = Output;
 
             var bound = Output.Description.DesktopBounds;
@@ -43,7 +41,7 @@ namespace Captura.Windows.DesktopDuplication
 
                 _bkpTexture?.Dispose();
 
-                _device.Dispose();
+                // Device is owned by the editor session, do not dispose here
                 _device = null;
             }
         }

--- a/src/Captura.Windows/DesktopDuplication/FullScreenDesktopDuplicator.cs
+++ b/src/Captura.Windows/DesktopDuplication/FullScreenDesktopDuplicator.cs
@@ -1,4 +1,4 @@
-﻿// Adapted from https://github.com/jasonpang/desktop-duplication-net
+// Adapted from https://github.com/jasonpang/desktop-duplication-net
 
 using SharpDX.DXGI;
 using System;
@@ -42,7 +42,7 @@ namespace Captura.Windows.DesktopDuplication
 
                 return new DeskDuplOutputEntry
                 {
-                    DuplCapture = new DuplCapture(output1),
+                    DuplCapture = new DuplCapture(output1, _editorSession.Device),
                     Location = new SharpDX.Point(rect.Left - bounds.Left, rect.Top - bounds.Top),
                     MousePointer = IncludeCursor ? new DxMousePointer(_editorSession) : null
                 };

--- a/src/Captura.Windows/WindowsGraphicsCapture/WgcCapture.cs
+++ b/src/Captura.Windows/WindowsGraphicsCapture/WgcCapture.cs
@@ -23,20 +23,20 @@ namespace Captura.Windows.WindowsGraphicsCapture
         readonly int _width;
         readonly int _height;
         
-        public WgcCapture(IntPtr handle, int width, int height, bool isMonitor = false)
+        public WgcCapture(Device device, IntPtr handle, int width, int height, bool isMonitor = false)
         {
             _width = width;
             _height = height;
             
-            _device = new Device(SharpDX.Direct3D.DriverType.Hardware, 
-                DeviceCreationFlags.BgraSupport);
+            // Use the same D3D11 device as the editor session to avoid cross-device copies
+            _device = device ?? throw new ArgumentNullException(nameof(device));
             
             _captureItem = isMonitor 
                 ? CaptureHelper.CreateItemForMonitor(handle)
                 : CaptureHelper.CreateItemForWindow(handle);
             
             if (_captureItem == null)
-                throw new Exception("Failed to create GraphicsCaptureItem");
+                throw new NotSupportedException("Windows Graphics Capture is unavailable on this system. Switch Screen Capture Method to Desktop Duplication or GDI in Settings → Video.");
             
             var d3dDevice = CreateDirect3DDevice(_device);
             
@@ -89,7 +89,6 @@ namespace Captura.Windows.WindowsGraphicsCapture
                 _session?.Dispose();
                 _framePool?.Dispose();
                 _lastFrame?.Dispose();
-                _device?.Dispose();
             }
         }
         

--- a/src/Captura.Windows/WindowsGraphicsCapture/WgcCaptureSession.cs
+++ b/src/Captura.Windows/WindowsGraphicsCapture/WgcCaptureSession.cs
@@ -12,7 +12,8 @@ namespace Captura.Windows.WindowsGraphicsCapture
         public WgcCaptureSession(IntPtr handle, int width, int height, IPreviewWindow previewWindow, bool isMonitor = false)
         {
             _editorSession = new Direct2DEditorSession(width, height, previewWindow);
-            _wgcCapture = new WgcCapture(handle, width, height, isMonitor);
+            // Share the same D3D11 device with WGC to ensure textures are compatible
+            _wgcCapture = new WgcCapture(_editorSession.Device, handle, width, height, isMonitor);
         }
         
         public IEditableFrame Capture()

--- a/src/Captura.Windows/WindowsPlatformServices.cs
+++ b/src/Captura.Windows/WindowsPlatformServices.cs
@@ -131,7 +131,7 @@ namespace Captura.Windows
                 return new DeskDuplImageProvider(output, IncludeCursor, _previewWindow);
             }
             
-            throw new Exception("No screen output found for Desktop Duplication. Enable WGC or GDI mode in settings.");
+            throw new NotSupportedException("Desktop Duplication is unavailable on this GPU/driver. Try Windows Graphics Capture (WGC) or GDI mode in Settings → Video.");
         }
 
         static Output1 FindOutput(IScreen Screen)
@@ -161,11 +161,8 @@ namespace Captura.Windows
                 return GetRegionProvider(DesktopRectangle, IncludeCursor);
             }
             
-            if (WindowsModule.ShouldUseWgc)
-            {
-                return new WgcScreenImageProvider(DesktopRectangle, _previewWindow);
-            }
-            
+            // Prefer Desktop Duplication for full-desktop (multi-monitor) capture.
+            // WGC can only capture one monitor at a time; using it here would miss other displays.
             return new DeskDuplFullScreenImageProvider(IncludeCursor, _previewWindow, this);
         }
     }

--- a/src/Captura/Captura.csproj
+++ b/src/Captura/Captura.csproj
@@ -11,11 +11,13 @@
     <UseAppConfigForCompiler>true</UseAppConfigForCompiler>
     <ApplicationIcon>Images\Captura.ico</ApplicationIcon>
     <Prefer32Bit>false</Prefer32Bit>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <None Include="app.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="app.manifest" />
   </ItemGroup>
   <Target Name="CopyAppConfig" AfterTargets="Build">
     <Copy SourceFiles="app.config" DestinationFiles="$(OutputPath)$(AssemblyName).exe.config" />

--- a/src/Captura/app.manifest
+++ b/src/Captura/app.manifest
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <assemblyIdentity version="1.0.0.0" name="Captura.app"/>
+  <description>Captura Screen Recorder</description>
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 10 -->
+    </asmv3:windowsSettings>
+  </asmv3:application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
Fix screen and fullscreen recording issues on some devices by sharing D3D11 devices, preferring Desktop Duplication for multi-monitor, and adding a Windows 10+ compatibility manifest.

Screen and fullscreen recording were failing on certain devices due to issues with Direct3D 11 device compatibility and capture method selection. This PR ensures the D3D11 device is shared between Windows Graphics Capture (WGC) and the editor session to prevent cross-device copy failures. For multi-monitor "All Screens" capture, Desktop Duplication is now explicitly used as WGC is limited to single-monitor capture. An application manifest was also added to correctly declare Windows 10+ compatibility and DPI awareness, which is essential for WGC to function reliably. Improved error messages guide users to alternative capture methods when one fails.

---
<a href="https://cursor.com/background-agent?bcId=bc-90d72caa-ff2c-40bb-9ec0-d0e03025b0b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90d72caa-ff2c-40bb-9ec0-d0e03025b0b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

