### PR TITLE
Fix video recording preview breaking with sound

### DIFF
--- a/src/Captura.Core/WithPreviewWriter.cs
+++ b/src/Captura.Core/WithPreviewWriter.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Captura.Video
 {
@@ -15,9 +15,16 @@ namespace Captura.Video
 
         public void Dispose()
         {
-            OriginalWriter.Dispose();
-            OriginalWriter = null;
-            _preview.Dispose();
+            // Ensure preview is disposed even if original writer throws
+            try
+            {
+                OriginalWriter?.Dispose();
+            }
+            finally
+            {
+                OriginalWriter = null;
+                _preview.Dispose();
+            }
         }
 
         public void WriteFrame(IBitmapFrame Image)

--- a/src/Captura.FFmpeg/Audio/FFmpegAudioWriter.cs
+++ b/src/Captura.FFmpeg/Audio/FFmpegAudioWriter.cs
@@ -39,7 +39,14 @@ namespace Captura.FFmpeg
             try
             {
                 Flush();
-                _ffmpegIn.Close();
+                try
+                {
+                    _ffmpegIn.Close();
+                }
+                catch { }
+
+                // Ask FFmpeg to quit gracefully
+                FFmpegService.TryGracefulStop(_ffmpegProcess);
 
                 if (!_ffmpegProcess.WaitForExit(10000))
                 {

--- a/src/Captura.FFmpeg/Video/FFmpegVideoWriter.cs
+++ b/src/Captura.FFmpeg/Video/FFmpegVideoWriter.cs
@@ -19,10 +19,10 @@ namespace Captura.FFmpeg
         byte[] _videoBuffer;
 
         // This semaphore helps prevent FFmpeg audio/video pipes getting deadlocked.
-        readonly SemaphoreSlim _spVideo = new SemaphoreSlim(5);
+        readonly SemaphoreSlim _spVideo = new SemaphoreSlim(2);
 
         // Timeout used with Semaphores, if elapsed would mean FFmpeg might be deadlocked.
-        readonly TimeSpan _spTimeout = TimeSpan.FromMilliseconds(50);
+        readonly TimeSpan _spTimeout = TimeSpan.FromMilliseconds(15);
 
         static string GetPipeName() => $"captura-{Guid.NewGuid()}";
 
@@ -121,6 +121,9 @@ namespace Captura.FFmpeg
                     _audioPipe?.Flush();
                 }
                 catch { }
+
+                // Signal FFmpeg to exit gracefully before disposing pipes.
+                FFmpegService.TryGracefulStop(_ffmpegProcess);
 
                 _ffmpegIn?.Dispose();
                 _audioPipe?.Dispose();

--- a/src/Screna/Recorder.cs
+++ b/src/Screna/Recorder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -277,14 +277,14 @@ namespace Captura.Video
             try
             {
                 if (_frameWriteTask != null)
-                    await _frameWriteTask;
+                    await _frameWriteTask.ConfigureAwait(false);
             }
             catch { }
 
             try
             {
                 if (_audioWriteTask != null)
-                    await _audioWriteTask;
+                    await _audioWriteTask.ConfigureAwait(false);
             }
             catch { }
 


### PR DESCRIPTION
Implement robust FFmpeg process management and pipe handling to fix recording preview breaks and hanging processes when audio is enabled.

The issue stemmed from FFmpeg processes not being gracefully shut down, especially when audio was involved, leading to pipes remaining open and the process hanging. This also caused the preview to break and required manual termination of both the app and FFmpeg. The changes ensure FFmpeg processes are tracked, given a chance to exit gracefully, and forcefully terminated if necessary, along with safer pipe management.

---
<a href="https://cursor.com/background-agent?bcId=bc-57db2243-f448-4115-a043-74506eb29605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57db2243-f448-4115-a043-74506eb29605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

