### PR TITLE
Adjust webcam slider click increment

### DIFF
--- a/src/Captura/Pages/WebcamPage.xaml
+++ b/src/Captura/Pages/WebcamPage.xaml
@@ -74,6 +74,7 @@
                 <Slider Grid.Column="2"
                         Minimum="1"
                         Maximum="100"
+                        LargeChange="10"
                         Value="{Binding Opacity, Mode=TwoWay}"/>
             </Grid>
         </StackPanel>
@@ -88,6 +89,7 @@
                 <Slider Value="{Binding Scale, Mode=TwoWay}"
                         TickPlacement="BottomRight"
                         TickFrequency="0.1"
+                        LargeChange="0.1"
                         Minimum="0"
                         Maximum="1"/>
             </DockPanel>
@@ -100,6 +102,7 @@
                     <Label Content="X"
                            Margin="0,0,5,0"/>
                     <Slider Value="{Binding XLoc, Mode=TwoWay}"
+                            LargeChange="0.1"
                             Minimum="0"
                             Maximum="1"/>
                 </DockPanel>
@@ -112,6 +115,7 @@
                     <Slider Value="{Binding YLoc, Mode=TwoWay}"
                             Orientation="Vertical"
                             IsDirectionReversed="True"
+                            LargeChange="0.1"
                             Minimum="0"
                             Maximum="1"/>
                 </DockPanel>


### PR DESCRIPTION
Set `LargeChange` property for webcam configuration sliders to prevent them from jumping to extremes when clicked.

---
<a href="https://cursor.com/background-agent?bcId=bc-9defd2a1-f883-4e04-b0f2-999e6c0cdefb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9defd2a1-f883-4e04-b0f2-999e6c0cdefb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

