### PR TITLE
Remove trim tool separator in config

### DIFF
--- a/src/Captura/Pages/SettingsPage.xaml
+++ b/src/Captura/Pages/SettingsPage.xaml
@@ -64,8 +64,6 @@
                                           CommandParameter="/Pages/AboutPage.xaml"/>
                 </WrapPanel>
                 
-                <Separator Margin="20,15" Height="1"/>
-                
                 <captura:ModernButton Content="{Binding Trim, Source={StaticResource Loc}, Mode=OneWay}"
                                       IconData="{Binding Icons.Trim, Source={StaticResource ServiceLocator}}"
                                       HorizontalAlignment="Center"


### PR DESCRIPTION
Remove the separator above the trim tool in the configure window as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4f6f33f-f227-431b-88ee-d148734f80d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c4f6f33f-f227-431b-88ee-d148734f80d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

