### PR TITLE
Fix null filename error when saving screenshots

### DIFF
--- a/src/Captura.Core/Models/EditorWriter.cs
+++ b/src/Captura.Core/Models/EditorWriter.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Captura.Models
@@ -6,15 +6,25 @@ namespace Captura.Models
     // ReSharper disable once ClassNeverInstantiated.Global
     public class EditorWriter : NotifyPropertyChanged, IImageWriterItem
     {
+        readonly Settings _settings;
+
+        public EditorWriter(Settings Settings)
+        {
+            _settings = Settings;
+        }
+
         public Task Save(IBitmapImage Image, ImageFormats Format, string FileName)
         {
-            if (!File.Exists(FileName))
+            var extension = Format.ToString().ToLower();
+            var fileName = _settings.GetFileName(extension, FileName);
+
+            if (!File.Exists(fileName))
             {
-                Image.Save(FileName, Format);
+                Image.Save(fileName, Format);
             }
 
             var winserv = ServiceProvider.Get<IMainWindow>();
-            winserv.EditImage(FileName);
+            winserv.EditImage(fileName);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Generate a filename in `EditorWriter` to fix `ArgumentNullException` when saving edited screenshots.

---
<a href="https://cursor.com/background-agent?bcId=bc-de2fb982-19b0-4790-a685-13d7dfa7e54f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-de2fb982-19b0-4790-a685-13d7dfa7e54f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

