### PR TITLE
Save and restore drawing tool color

### DIFF
--- a/src/Captura.Base/Settings/RegionSelectorSettings.cs
+++ b/src/Captura.Base/Settings/RegionSelectorSettings.cs
@@ -1,0 +1,13 @@
+using System.Drawing;
+
+namespace Captura
+{
+    public class RegionSelectorSettings : PropertyStore
+    {
+        public Color BrushColor
+        {
+            get => Get(Color.FromArgb(27, 27, 27));
+            set => Set(value);
+        }
+    }
+}

--- a/src/Captura.Core/Settings/Settings.cs
+++ b/src/Captura.Core/Settings/Settings.cs
@@ -115,6 +115,8 @@ namespace Captura
 
         public WindowsSettings WindowsSettings { get; }
 
+        public RegionSelectorSettings RegionSelector { get; } = new RegionSelectorSettings();
+
         public int PreStartCountdown
         {
             get => Get(0);

--- a/src/Captura/ViewModels/RegionSelectorViewModel.cs
+++ b/src/Captura/ViewModels/RegionSelectorViewModel.cs
@@ -14,6 +14,8 @@ namespace Captura.ViewModels
     // ReSharper disable once ClassNeverInstantiated.Global
     public class RegionSelectorViewModel : NotifyPropertyChanged
     {
+        readonly Settings _settings;
+        
         int _left = 50,
             _top = 50,
             _width = 500,
@@ -25,8 +27,21 @@ namespace Captura.ViewModels
 
         public const int BorderSize = 3;
 
-        public RegionSelectorViewModel()
+        public RegionSelectorViewModel(Settings Settings)
         {
+            _settings = Settings;
+            
+            // Initialize BrushColor from settings
+            var savedColor = _settings.RegionSelector.BrushColor;
+            BrushColor = new ReactiveProperty<Color>(Color.FromRgb(savedColor.R, savedColor.G, savedColor.B));
+            
+            // Subscribe to BrushColor changes to save to settings
+            BrushColor.Subscribe(color =>
+            {
+                var drawingColor = System.Drawing.Color.FromArgb(color.R, color.G, color.B);
+                _settings.RegionSelector.BrushColor = drawingColor;
+            });
+            
             MoveLeftCommand = new ReactiveCommand()
                 .WithSubscribe(() => Left -= KeyMoveDelta);
             MoveRightCommand = new ReactiveCommand()
@@ -58,7 +73,7 @@ namespace Captura.ViewModels
 
         public IReactiveProperty<int> BrushSize { get; } = new ReactiveProperty<int>(10);
 
-        public IReactiveProperty<Color> BrushColor { get; } = new ReactiveProperty<Color>(Color.FromRgb(27, 27, 27));
+        public IReactiveProperty<Color> BrushColor { get; }
 
         public int Left
         {


### PR DESCRIPTION
Persist the drawing tool color across application sessions.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb06f9a0-6ee9-4a88-9482-a16d315ad48e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb06f9a0-6ee9-4a88-9482-a16d315ad48e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

