### PR TITLE
Fix tray icon left click actions

### DIFF
--- a/src/Captura/Pages/TrayIconPage.xaml
+++ b/src/Captura/Pages/TrayIconPage.xaml
@@ -1,7 +1,7 @@
-﻿<Page x:Class="Captura.TrayIconPage"
+<Page x:Class="Captura.TrayIconPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:hotkeys="clr-namespace:Captura;assembly=Captura.Hotkeys"
+      xmlns:hotkeys="clr-namespace:Captura.Hotkeys;assembly=Captura.Hotkeys"
       Title="{Binding TrayIcon, Source={StaticResource Loc}, Mode=OneWay}"
       DataContext="{Binding MainViewModel, Source={StaticResource ServiceLocator}}">
     <Grid Margin="10">
@@ -18,6 +18,12 @@
                            Text="{Binding MinTrayClose, Source={StaticResource Loc}, Mode=OneWay}"/>
             </CheckBox>
 
+            <CheckBox IsChecked="{Binding Settings.Tray.MinToTrayOnCaptureStart}"
+                      Margin="0,2">
+                <TextBlock TextWrapping="Wrap"
+                           Text="{Binding MinToTrayOnCaptureStart, Source={StaticResource Loc}, Mode=OneWay}"/>
+            </CheckBox>
+
             <CheckBox IsChecked="{Binding Settings.Tray.ShowNotifications}"
                       Margin="0,2">
                 <TextBlock TextWrapping="Wrap"
@@ -30,8 +36,8 @@
 
                 <ComboBox SelectedValue="{Binding Settings.Tray.LeftClickAction, Mode=TwoWay}"
                           SelectedValuePath="ServiceName"
-                          DisplayMemberPath="Description.Display"
-                          ItemsSource="{Binding HotkeysViewModel.AllServices, Source={StaticResource ServiceLocator}}"/>
+                          DisplayMemberPath="Description"
+                          ItemsSource="{x:Static hotkeys:HotKeyManager.AllServices}"/>
             </DockPanel>
         </StackPanel>
     </Grid>


### PR DESCRIPTION
Fix missing tray icon left-click actions by correcting `TrayIconPage.xaml`.

The `TrayIconPage.xaml` file had an incorrect namespace, a missing "MinToTrayOnCaptureStart" checkbox, a broken ComboBox binding to a non-existent source, and an incorrect `DisplayMemberPath`, which collectively prevented the tray icon left-click actions from populating. This PR restores the file to its correct state, matching the `main` branch.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e0d415b-07ee-457d-9d39-09dfa8a88251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e0d415b-07ee-457d-9d39-09dfa8a88251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

