### PR TITLE
Fix hotkey display and add functionality

### DIFF
--- a/src/Captura.Hotkeys/HotKey.cs
+++ b/src/Captura.Hotkeys/HotKey.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Windows.Forms;
 using Captura.Native;
@@ -68,9 +68,27 @@ namespace Captura.Hotkeys
             }
         }
         
-        public Keys Key { get; private set; }
+        Keys _key;
+        public Keys Key
+        {
+            get => _key;
+            private set
+            {
+                _key = value;
+                OnPropertyChanged();
+            }
+        }
 
-        public Modifiers Modifiers { get; private set; }
+        Modifiers _modifiers;
+        public Modifiers Modifiers
+        {
+            get => _modifiers;
+            private set
+            {
+                _modifiers = value;
+                OnPropertyChanged();
+            }
+        }
 
         public void Change(Keys NewKey, Modifiers NewModifiers)
         {

--- a/src/Captura.ViewCore/ViewModels/HotkeysViewModel.cs
+++ b/src/Captura.ViewCore/ViewModels/HotkeysViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Windows.Input;
 using Captura.Hotkeys;
 using Reactive.Bindings;
@@ -9,6 +10,8 @@ namespace Captura.ViewModels
     public class HotkeysViewModel
     {
         public ReadOnlyObservableCollection<Hotkey> Hotkeys { get; }
+
+        public IEnumerable<Service> AllServices => HotKeyManager.AllServices;
 
         public HotkeysViewModel(HotKeyManager HotKeyManager)
         {

--- a/src/Captura/Controls/HotkeySelector.cs
+++ b/src/Captura/Controls/HotkeySelector.cs
@@ -33,6 +33,13 @@ namespace Captura
                 {
                     if (E.PropertyName == nameof(Hotkey.IsActive))
                         selector.TextColor();
+                    
+                    // Update display when Key or Modifiers change
+                    if (E.PropertyName == nameof(Hotkey.Key) || E.PropertyName == nameof(Hotkey.Modifiers))
+                    {
+                        if (!selector._editing)
+                            selector.Content = hotkey.ToString();
+                    }
                 };
 
                 selector.Content = hotkey.ToString();

--- a/src/Captura/Pages/HotkeysPage.xaml
+++ b/src/Captura/Pages/HotkeysPage.xaml
@@ -76,7 +76,7 @@
                                 <CheckBox IsChecked="{Binding IsActive, Mode=TwoWay}"/>
 
                                 <ComboBox SelectedValue="{Binding Service, Mode=TwoWay}"
-                                          DisplayMemberPath="Description.Display"
+                                          DisplayMemberPath="Description"
                                           ItemsSource="{x:Static hotkeys:HotKeyManager.AllServices}"
                                           Margin="10,0"
                                           IsEnabled="{Binding IsActive}"/>

--- a/src/Captura/Pages/HotkeysPage.xaml
+++ b/src/Captura/Pages/HotkeysPage.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:local="clr-namespace:Captura"
       xmlns:hotkeys="clr-namespace:Captura.Hotkeys;assembly=Captura.Hotkeys"
-      DataContext="{Binding HotKeyManager, Source={StaticResource ServiceLocator}}">
+      DataContext="{Binding HotkeysViewModel, Source={StaticResource ServiceLocator}}">
     <Grid>
         <DockPanel Margin="5">
             <Grid DockPanel.Dock="Top">
@@ -61,7 +61,7 @@
                                 <local:ModernButton DockPanel.Dock="Right"
                                                     CommandParameter="{Binding}"
                                                     IconData="{Binding Icons.Close, Source={StaticResource ServiceLocator}}"
-                                                    Command="{Binding HotKeyManager.RemoveCommand, Source={StaticResource ServiceLocator}}">
+                                                    Command="{Binding DataContext.RemoveCommand, RelativeSource={RelativeSource AncestorType=Page}}">
                                     <local:ModernButton.LayoutTransform>
                                         <ScaleTransform ScaleX="0.8" ScaleY="0.8"/>
                                     </local:ModernButton.LayoutTransform>


### PR DESCRIPTION
Fix hotkey display and add/remove functionality in the configuration page.

The `HotkeysPage.xaml` was incorrectly bound to `HotKeyManager` instead of `HotkeysViewModel`, preventing hotkey commands from working. Additionally, the `Hotkey` class's `Key` and `Modifiers` properties did not raise `PropertyChanged` events, causing display issues when hotkeys were modified.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7a7b2ba-dd10-48b0-9b52-41bcb4b84086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7a7b2ba-dd10-48b0-9b52-41bcb4b84086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

