### PR TITLE
Fix overlay preview highlight circle bug

### DIFF
--- a/src/Captura/Pages/OverlayConfigPage.xaml.cs
+++ b/src/Captura/Pages/OverlayConfigPage.xaml.cs
@@ -305,9 +305,6 @@ namespace Captura
 
         void UIElement_OnMouseMove(object Sender, MouseEventArgs E)
         {
-            if (ServiceProvider.Get<Settings>().MousePointerOverlay.Display)
-                MousePointer.Visibility = Visibility.Visible;
-
             var position = E.GetPosition(Grid);
 
             if (IsOutsideGrid(position))
@@ -315,6 +312,12 @@ namespace Captura
                 MousePointer.Visibility = Visibility.Collapsed;
                 return;
             }
+
+            // Show/hide circle based on DisplayHighlight setting
+            if (ServiceProvider.Get<Settings>().MousePointerOverlay.DisplayHighlight)
+                MousePointer.Visibility = Visibility.Visible;
+            else
+                MousePointer.Visibility = Visibility.Collapsed;
 
             if (_dragging)
                 UpdateMouseClickPosition(position);


### PR DESCRIPTION
Fix overlay preview highlight circle not hiding when 'Display Highlight Circle' is unchecked.

The preview logic was incorrectly checking `MousePointerOverlay.Display` instead of `MousePointerOverlay.DisplayHighlight` to control the visibility of the highlight circle. This change ensures the preview respects the `DisplayHighlight` setting, matching the behavior in `main` and `OverlayPage`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8adeeb44-d30c-4821-b305-de7779652ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8adeeb44-d30c-4821-b305-de7779652ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

