### PR TITLE
Filter encoding settings by hardware

### DIFF
--- a/src/Captura.Base/Services/IHardwareInfoService.cs
+++ b/src/Captura.Base/Services/IHardwareInfoService.cs
@@ -1,0 +1,39 @@
+namespace Captura
+{
+    public enum GpuVendor
+    {
+        Unknown,
+        AMD,
+        NVIDIA,
+        Intel,
+        Other
+    }
+
+    public interface IHardwareInfoService
+    {
+        /// <summary>
+        /// Gets the primary GPU vendor
+        /// </summary>
+        GpuVendor GpuVendor { get; }
+
+        /// <summary>
+        /// Gets the GPU name/description
+        /// </summary>
+        string GpuName { get; }
+
+        /// <summary>
+        /// Checks if AMD hardware encoding is available
+        /// </summary>
+        bool HasAmdEncoder { get; }
+
+        /// <summary>
+        /// Checks if NVIDIA hardware encoding is available
+        /// </summary>
+        bool HasNvidiaEncoder { get; }
+
+        /// <summary>
+        /// Checks if Intel QuickSync encoding is available
+        /// </summary>
+        bool HasIntelQuickSync { get; }
+    }
+}

--- a/src/Captura.Windows/HardwareInfoService.cs
+++ b/src/Captura.Windows/HardwareInfoService.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using SharpDX.DXGI;
+
+namespace Captura.Windows
+{
+    public class HardwareInfoService : IHardwareInfoService
+    {
+        public GpuVendor GpuVendor { get; }
+        public string GpuName { get; }
+        public bool HasAmdEncoder { get; }
+        public bool HasNvidiaEncoder { get; }
+        public bool HasIntelQuickSync { get; }
+
+        public HardwareInfoService()
+        {
+            try
+            {
+                using var factory = new Factory1();
+                var adapter = factory.Adapters1.FirstOrDefault();
+                
+                if (adapter != null)
+                {
+                    GpuName = adapter.Description.Description ?? "Unknown GPU";
+                    GpuVendor = DetectVendor(adapter);
+                    
+                    // Set encoder availability based on vendor
+                    HasAmdEncoder = GpuVendor == Captura.GpuVendor.AMD;
+                    HasNvidiaEncoder = GpuVendor == Captura.GpuVendor.NVIDIA;
+                    HasIntelQuickSync = GpuVendor == Captura.GpuVendor.Intel;
+                }
+                else
+                {
+                    GpuName = "No GPU detected";
+                    GpuVendor = Captura.GpuVendor.Unknown;
+                    HasAmdEncoder = false;
+                    HasNvidiaEncoder = false;
+                    HasIntelQuickSync = false;
+                }
+            }
+            catch (Exception)
+            {
+                // If detection fails, default to unknown and allow all encoders
+                // (better to show too many options than too few)
+                GpuName = "Detection failed";
+                GpuVendor = Captura.GpuVendor.Unknown;
+                HasAmdEncoder = true; // Allow all when detection fails
+                HasNvidiaEncoder = true;
+                HasIntelQuickSync = true;
+            }
+        }
+
+        private static GpuVendor DetectVendor(Adapter1 adapter)
+        {
+            var vendorId = adapter.Description.VendorId;
+            
+            // Common GPU vendor IDs
+            // AMD: 0x1002
+            // NVIDIA: 0x10DE
+            // Intel: 0x8086
+            
+            return vendorId switch
+            {
+                0x1002 => Captura.GpuVendor.AMD,
+                0x10DE => Captura.GpuVendor.NVIDIA,
+                0x8086 => Captura.GpuVendor.Intel,
+                _ => DetermineVendorFromName(adapter.Description.Description)
+            };
+        }
+
+        private static GpuVendor DetermineVendorFromName(string gpuName)
+        {
+            if (string.IsNullOrEmpty(gpuName))
+                return Captura.GpuVendor.Unknown;
+
+            var lowerName = gpuName.ToLowerInvariant();
+            
+            if (lowerName.Contains("amd") || lowerName.Contains("radeon") || lowerName.Contains("ati"))
+                return Captura.GpuVendor.AMD;
+                
+            if (lowerName.Contains("nvidia") || lowerName.Contains("geforce") || lowerName.Contains("quadro") || lowerName.Contains("tesla"))
+                return Captura.GpuVendor.NVIDIA;
+                
+            if (lowerName.Contains("intel") || lowerName.Contains("hd graphics") || lowerName.Contains("uhd graphics") || lowerName.Contains("iris"))
+                return Captura.GpuVendor.Intel;
+            
+            return Captura.GpuVendor.Unknown;
+        }
+    }
+}

--- a/src/Captura.Windows/WindowsModule.cs
+++ b/src/Captura.Windows/WindowsModule.cs
@@ -13,7 +13,7 @@ namespace Captura.Windows
         public static void Load(IBinder Binder)
         {
             // Register hardware detection service first, as it's used by encoder providers
-            Binder.BindSingleton<IHardwareInfoService, HardwareInfoService>();
+            Binder.Bind<IHardwareInfoService, HardwareInfoService>();
 
             if (Windows8OrAbove)
             {

--- a/src/Captura.Windows/WindowsModule.cs
+++ b/src/Captura.Windows/WindowsModule.cs
@@ -12,6 +12,9 @@ namespace Captura.Windows
     {
         public static void Load(IBinder Binder)
         {
+            // Register hardware detection service first, as it's used by encoder providers
+            Binder.BindSingleton<IHardwareInfoService, HardwareInfoService>();
+
             if (Windows8OrAbove)
             {
                 try


### PR DESCRIPTION
Filter FFmpeg encoding options based on detected GPU hardware to show only relevant encoders.

This change prevents showing hardware-accelerated encoding options (e.g., AMD AMF to NVIDIA users) that are incompatible with the user's system, reducing confusion and simplifying the selection of encoding settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ac3ce36-5d90-42d3-a532-af72b63c1ed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ac3ce36-5d90-42d3-a532-af72b63c1ed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

