### PR TITLE
Rearrange about and trim tool tabs

### DIFF
--- a/src/Captura/Pages/AboutPage.xaml
+++ b/src/Captura/Pages/AboutPage.xaml
@@ -118,26 +118,6 @@
                     </DockPanel>
                 </Button>
 
-                <Label Margin="0,15,0,5">
-                    <TextBlock Text="{Binding Tools, Source={StaticResource Loc}, Mode=OneWay}"/>
-                </Label>
-                
-                <WrapPanel Margin="3">
-                    <!-- Image Editor button removed - internal editor was removed, external editor is available via toggle in main UI -->
-                    <!-- Crop and Imgur upload buttons removed - features no longer working/supported -->
-
-                    <Button ToolTip="{Binding Trim, Source={StaticResource Loc}, Mode=OneWay}"
-                            Padding="5"
-                            Margin="0,0,10,10"
-                            Click="OpenAudioVideoTrimmer">
-                        <Path Data="{Binding Icons.Trim, Source={StaticResource ServiceLocator}}"
-                              Width="15"
-                              Height="15"
-                              Stretch="Uniform"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"/>
-                    </Button>
-                </WrapPanel>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/src/Captura/Pages/AboutPage.xaml.cs
+++ b/src/Captura/Pages/AboutPage.xaml.cs
@@ -14,12 +14,5 @@ namespace Captura
         {
             NavigationService?.Navigate(new CrashLogsPage());
         }
-
-        // OpenImageEditor, OpenImageCropper, and UploadToImgur methods removed - features no longer supported
-
-        void OpenAudioVideoTrimmer(object Sender, RoutedEventArgs E)
-        {
-            new TrimmerWindow().ShowAndFocus();
-        }
     }
 }

--- a/src/Captura/Pages/MainPage.xaml
+++ b/src/Captura/Pages/MainPage.xaml
@@ -109,15 +109,6 @@
 
                 <Frame Source="RecentPage.xaml"/>
             </TabItem>
-            <TabItem>
-                <TabItem.Header>
-                    <Path Data="{Binding Icons.Help, Source={StaticResource ServiceLocator}}"
-                          Style="{StaticResource TabIcon}"
-                          ToolTip="{Binding About, Source={StaticResource Loc}, Mode=OneWay}"/>
-                </TabItem.Header>
-                
-                <Frame Source="AboutPage.xaml"/>
-            </TabItem>
         </TabControl>
     </DockPanel>
 </Page>

--- a/src/Captura/Pages/SettingsPage.xaml
+++ b/src/Captura/Pages/SettingsPage.xaml
@@ -53,6 +53,12 @@
             <TabItem Header="FFmpeg">
                 <Frame Source="FFmpegPage.xaml"/>
             </TabItem>
+            <TabItem Header="{Binding Trim, Source={StaticResource Loc}, Mode=OneWay}">
+                <Frame Source="TrimmerPage.xaml"/>
+            </TabItem>
+            <TabItem Header="{Binding About, Source={StaticResource Loc}, Mode=OneWay}">
+                <Frame Source="AboutPage.xaml"/>
+            </TabItem>
         </TabControl>
     </Grid>
 </Page>


### PR DESCRIPTION
Move About page to Configure window and integrate Trim tool as a new tab within the Configure window.

The Trim tool was previously a button on the About page that opened a separate window. This change integrates it directly into the settings/configure window for a more streamlined user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4fa617c-a13a-4fe0-82ad-51baa7164ee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4fa617c-a13a-4fe0-82ad-51baa7164ee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

