### PR TITLE
Auto confirm region selection after drag

### DIFF
--- a/src/Captura/Windows/RegionPickerWindow.xaml.cs
+++ b/src/Captura/Windows/RegionPickerWindow.xaml.cs
@@ -122,34 +122,13 @@ namespace Captura
             _end = E.GetPosition(Grid);
             Border.Visibility = Visibility.Collapsed;
 
-            var layer = AdornerLayer.GetAdornerLayer(Grid);
-
             var rect = GetRegion();
-
-            UpdateSizeDisplay(rect);
 
             if (rect == null)
                 return;
 
-            _croppingAdorner = new CroppingAdorner(Grid, rect.Value);
-
-            var clr = Colors.Black;
-            clr.A = 110;
-            _croppingAdorner.Fill = new SolidColorBrush(clr);
-
-            layer.Add(_croppingAdorner);
-
-            _croppingAdorner.CropChanged += (S, Args) => UpdateSizeDisplay(_croppingAdorner.SelectedRegion);
-
-            _croppingAdorner.Checked += () =>
-            {
-                var r = _croppingAdorner.SelectedRegion;
-
-                _start = r.Location;
-                _end = r.BottomRight;
-
-                Close();
-            };
+            // Auto-confirm the selection without showing the cropping adorner
+            Close();
         }
 
         Rect? GetRegion()

--- a/src/Captura/Windows/VideoSourcePickerWindow.xaml
+++ b/src/Captura/Windows/VideoSourcePickerWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="Captura.VideoSourcePickerWindow"
+<Window x:Class="Captura.VideoSourcePickerWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -21,7 +21,7 @@
                         Executed="CloseClick"/>
     </Window.CommandBindings>
     <Grid MouseMove="WindowMouseMove"
-          MouseLeftButtonDown="WindowMouseLeftButtonDown"
+          MouseLeftButtonUp="WindowMouseLeftButtonUp"
           Name="Grid"
           Background="Transparent">
         <Grid.Resources>

--- a/src/Captura/Windows/VideoSourcePickerWindow.xaml.cs
+++ b/src/Captura/Windows/VideoSourcePickerWindow.xaml.cs
@@ -196,7 +196,7 @@ namespace Captura
             }
         }
 
-        void WindowMouseLeftButtonDown(object Sender, MouseButtonEventArgs E)
+        void WindowMouseLeftButtonUp(object Sender, MouseButtonEventArgs E)
         {
             switch (_mode)
             {


### PR DESCRIPTION
Change region selection confirmation from `MouseLeftButtonDown` to `MouseLeftButtonUp` to enable auto-confirmation on mouse release.

This restores the desired behavior where users can drag to select a region and the selection is confirmed automatically when the mouse button is released, without requiring an additional click.

---
<a href="https://cursor.com/background-agent?bcId=bc-e01fff0c-4dbb-451c-a12e-6178e9e38e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e01fff0c-4dbb-451c-a12e-6178e9e38e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

