### PR TITLE
Remove region window close button

### DIFF
--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -262,15 +262,6 @@
                                         WindowChrome.IsHitTestVisibleInChrome="True"
                                         ToolTip="{Binding SnapToWindow, Source={StaticResource Loc}, Mode=OneWay}"/>
 
-                    <local:ModernButton x:Name="CloseButton"
-                                        Click="CloseButton_Click"
-                                        Background="{DynamicResource WindowBackground}"
-                                        Foreground="#77ef5350"
-                                        IconData="{Binding Icons.Close, Source={StaticResource ServiceLocator}}"
-                                        DockPanel.Dock="Right"
-                                        WindowChrome.IsHitTestVisibleInChrome="True"
-                                        ToolTip="{Binding Close, Source={StaticResource Loc}, Mode=OneWay}"/>
-
                     <local:ModernButton Click="ScreenShotButton_Click"
                                         IconData="{Binding Icons.Camera, Source={StaticResource ServiceLocator}}"
                                         DockPanel.Dock="Right"

--- a/src/Captura/Windows/RegionSelector.xaml.cs
+++ b/src/Captura/Windows/RegionSelector.xaml.cs
@@ -251,13 +251,6 @@ namespace Captura
             };
         }
 
-        void CloseButton_Click(object Sender, RoutedEventArgs E)
-        {
-            Hide();
-
-            SelectorHidden?.Invoke();
-        }
-
         void ScreenShotButton_Click(object Sender, RoutedEventArgs E)
         {
             var screenShotViewModel = ServiceProvider.Get<ScreenShotViewModel>();
@@ -385,7 +378,7 @@ namespace Captura
             Dispatcher.Invoke(() =>
             {
                 ResizeMode = ResizeMode.NoResize;
-                Snapper.IsEnabled = CloseButton.IsEnabled = false;
+                Snapper.IsEnabled = false;
 
                 WidthBox.IsEnabled = HeightBox.IsEnabled = false;
             });
@@ -396,7 +389,7 @@ namespace Captura
             Dispatcher.Invoke(() =>
             {
                 ResizeMode = ResizeMode.CanResize;
-                Snapper.IsEnabled = CloseButton.IsEnabled = true;
+                Snapper.IsEnabled = true;
 
                 WidthBox.IsEnabled = HeightBox.IsEnabled = true;
 


### PR DESCRIPTION
Remove the close button from the region window toolbar to prevent user confusion about recording location.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e1575a4-42ed-4750-bd9d-9c79e8a76623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e1575a4-42ed-4750-bd9d-9c79e8a76623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

