### PR TITLE
Add delete all button to classic sidebar

### DIFF
--- a/src/Captura/Windows/RegionSelector.xaml
+++ b/src/Captura/Windows/RegionSelector.xaml
@@ -377,6 +377,17 @@
                         <ScaleTransform ScaleX="0.85" ScaleY="0.85"/>
                     </xctk:IntegerUpDown.LayoutTransform>
                 </xctk:IntegerUpDown>
+
+                <local:ModernButton ToolTip="Clear all drawings"
+                                    Foreground="#ff3330"
+                                    IconData="{Binding Icons.Delete, Source={StaticResource ServiceLocator}}"
+                                    DockPanel.Dock="Bottom"
+                                    Command="{Binding RegionSelectorViewModel.ClearAllDrawingsCommand, Source={StaticResource ServiceLocator}}"
+                                    Margin="0,2">
+                    <local:ModernButton.LayoutTransform>
+                        <ScaleTransform ScaleX="0.85" ScaleY="0.85"/>
+                    </local:ModernButton.LayoutTransform>
+                </local:ModernButton>
             </DockPanel>
 
             <Border.Style>

--- a/src/Captura/Windows/RegionSelector.xaml.cs
+++ b/src/Captura/Windows/RegionSelector.xaml.cs
@@ -126,6 +126,11 @@ namespace Captura
                     ModesBox.SelectedIndex = 0; // Set ListBox selection to Pointer
                 });
             
+            // Subscribe to ClearAllDrawingsCommand
+            regionSelectorViewModel
+                .ClearAllDrawingsCommand
+                .Subscribe(() => InkCanvas.Strokes.Clear());
+            
             // Add right-click handler to exit drawing mode
             InkCanvas.PreviewMouseRightButtonDown += (s, e) =>
             {


### PR DESCRIPTION
Add a 'Clear All Drawings' button to the classic sidebar's draw toolbar to match the functionality available in the main branch.

---
<a href="https://cursor.com/background-agent?bcId=bc-14f878fa-dc1c-4250-8ca2-6ccf65eb1321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14f878fa-dc1c-4250-8ca2-6ccf65eb1321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

