### PR TITLE
Update about page navigation to use configure arrows

### DIFF
--- a/src/Captura/Pages/AboutPage.xaml.cs
+++ b/src/Captura/Pages/AboutPage.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Controls;
 using Captura.Views;
 
 namespace Captura
@@ -7,12 +8,30 @@ namespace Captura
     {
         void ViewLicenses(object Sender, RoutedEventArgs E)
         {
-            NavigationService?.Navigate(new LicensesPage());
+            // Navigate using the immediate parent Frame (AboutFrame), not the grandparent
+            var parentFrame = Parent as Frame;
+            if (parentFrame != null)
+            {
+                parentFrame.Navigate(new LicensesPage());
+            }
+            else
+            {
+                NavigationService?.Navigate(new LicensesPage());
+            }
         }
 
         void ViewCrashLogs(object Sender, RoutedEventArgs E)
         {
-            NavigationService?.Navigate(new CrashLogsPage());
+            // Navigate using the immediate parent Frame (AboutFrame), not the grandparent
+            var parentFrame = Parent as Frame;
+            if (parentFrame != null)
+            {
+                parentFrame.Navigate(new CrashLogsPage());
+            }
+            else
+            {
+                NavigationService?.Navigate(new CrashLogsPage());
+            }
         }
     }
 }

--- a/src/Captura/Pages/SettingsPage.xaml
+++ b/src/Captura/Pages/SettingsPage.xaml
@@ -60,7 +60,27 @@
                 <Frame Source="TrimmerPage.xaml"/>
             </TabItem>
             <TabItem Header="{Binding About, Source={StaticResource Loc}, Mode=OneWay}">
-                <Frame Source="AboutPage.xaml"/>
+                <DockPanel>
+                    <DockPanel DockPanel.Dock="Top"
+                               Margin="5,5,5,10">
+                        <mui:ModernButton IconData="{Binding Icons.Back, Source={StaticResource ServiceLocator}}"
+                                          IsEnabled="{Binding CanGoBack, ElementName=AboutFrame}"
+                                          EllipseDiameter="40"
+                                          IconWidth="35"
+                                          IconHeight="25"
+                                          Margin="5,0,2,0"
+                                          Click="AboutBackButton_Click"/>
+                        
+                        <mui:ModernButton IconData="{Binding Icons.Forward, Source={StaticResource ServiceLocator}}"
+                                          IsEnabled="{Binding CanGoForward, ElementName=AboutFrame}"
+                                          Click="AboutForwardButton_Click"/>
+                    </DockPanel>
+                    <Frame x:Name="AboutFrame"
+                           Source="AboutPage.xaml"
+                           NavigationUIVisibility="Hidden"
+                           JournalOwnership="OwnsJournal"
+                           Navigated="AboutFrame_Navigated"/>
+                </DockPanel>
             </TabItem>
         </TabControl>
     </Grid>

--- a/src/Captura/Pages/SettingsPage.xaml.cs
+++ b/src/Captura/Pages/SettingsPage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows;
 using System.Windows.Navigation;
 
 namespace Captura
@@ -24,6 +25,37 @@ namespace Captura
                     webcamPage.SetupPreview();
                 }
             };
+        }
+
+        void AboutBackButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (AboutFrame.CanGoBack)
+            {
+                AboutFrame.GoBack();
+            }
+        }
+
+        void AboutForwardButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (AboutFrame.CanGoForward)
+            {
+                AboutFrame.GoForward();
+            }
+        }
+
+        void AboutFrame_Navigated(object sender, NavigationEventArgs e)
+        {
+            // Forcefully hide NavigationUI after navigation
+            if (sender is System.Windows.Controls.Frame frame)
+            {
+                frame.NavigationUIVisibility = NavigationUIVisibility.Hidden;
+                
+                // Also ensure the page itself doesn't have NavigationService chrome
+                if (e.Content is System.Windows.Controls.Page page)
+                {
+                    page.ShowsNavigationUI = false;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Replace the default `Frame` navigation bar with custom back/forward arrows in `SettingsWindow` to match the software's style.

---
<a href="https://cursor.com/background-agent?bcId=bc-a99ea98c-30ec-4c01-97ba-29a0363a958b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a99ea98c-30ec-4c01-97ba-29a0363a958b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

