### PR TITLE
Remove unused events in nCaptura

### DIFF
--- a/src/Captura.Loc/LanguageFields.cs
+++ b/src/Captura.Loc/LanguageFields.cs
@@ -27,7 +27,12 @@ namespace Captura.Loc
             RaisePropertyChanged(PropertyName);
         }
 
+        /// <summary>
+        /// Fired when the language changes. This event is invoked by derived classes (e.g., LanguageManager).
+        /// </summary>
+#pragma warning disable CS0067 // The event is never used - invoked by derived classes
         public virtual event Action<CultureInfo> LanguageChanged;
+#pragma warning restore CS0067
 
         public string About
         {

--- a/src/Captura.MouseKeyHook/Steps/StepsRecorder.cs
+++ b/src/Captura.MouseKeyHook/Steps/StepsRecorder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -167,23 +167,52 @@ namespace Captura.MouseKeyHook.Steps
 
         void DoRecord(IObservable<IRecordStep> StepsObservable, IObservable<Unit> ShotObservable)
         {
-            var frames = ShotObservable.Select(M => _imageProvider.Capture())
-                .Zip(StepsObservable, (Frame, Step) =>
-                {
-                    Step.Draw(Frame, _imageProvider.PointTransform);
-
-                    return Frame.GenerateFrame(TimeSpan.Zero);
-                });
-
-            foreach (var frame in frames.ToEnumerable())
+            try
             {
-                _videoWriter.WriteFrame(frame);
+                var frames = ShotObservable.Select(M => _imageProvider.Capture())
+                    .Zip(StepsObservable, (Frame, Step) =>
+                    {
+                        Step.Draw(Frame, _imageProvider.PointTransform);
+
+                        return Frame.GenerateFrame(TimeSpan.Zero);
+                    });
+
+                foreach (var frame in frames.ToEnumerable())
+                {
+                    _videoWriter.WriteFrame(frame);
+                }
+            }
+            catch (Exception e)
+            {
+                ErrorOccurred?.Invoke(e);
             }
         }
 
-        public void Start() => _recording = true;
+        public void Start()
+        {
+            try
+            {
+                _recording = true;
+            }
+            catch (Exception e)
+            {
+                ErrorOccurred?.Invoke(e);
+                throw;
+            }
+        }
 
-        public void Stop() => _recording = false;
+        public void Stop()
+        {
+            try
+            {
+                _recording = false;
+            }
+            catch (Exception e)
+            {
+                ErrorOccurred?.Invoke(e);
+                throw;
+            }
+        }
 
         public event Action<Exception> ErrorOccurred;
 

--- a/src/Screna/AudioRecorder.cs
+++ b/src/Screna/AudioRecorder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -54,16 +54,32 @@ namespace Captura.Audio
 
         public void Start()
         {
-            _audioProvider.Start();
+            try
+            {
+                _audioProvider.Start();
 
-            _continueEvent.Set();
+                _continueEvent.Set();
+            }
+            catch (Exception e)
+            {
+                ErrorOccurred?.Invoke(e);
+                throw;
+            }
         }
 
         public void Stop()
         {
-            _continueEvent.Reset();
+            try
+            {
+                _continueEvent.Reset();
 
-            _audioProvider.Stop();
+                _audioProvider.Stop();
+            }
+            catch (Exception e)
+            {
+                ErrorOccurred?.Invoke(e);
+                throw;
+            }
         }
 
         void Loop()
@@ -80,13 +96,20 @@ namespace Captura.Audio
                 }
             }
 
-            while (CanContinue())
+            try
             {
-                var read = _audioProvider.Read(_buffer, 0, _buffer.Length);
+                while (CanContinue())
+                {
+                    var read = _audioProvider.Read(_buffer, 0, _buffer.Length);
 
-                _audioWriter.Write(_buffer, 0, read);
+                    _audioWriter.Write(_buffer, 0, read);
 
-                Thread.Sleep(ReadInterval);
+                    Thread.Sleep(ReadInterval);
+                }
+            }
+            catch (Exception e)
+            {
+                ErrorOccurred?.Invoke(e);
             }
         }
 


### PR DESCRIPTION
Implement error handling for recorder events and suppress a warning for a virtual event to resolve "event never used" warnings.

The `ErrorOccurred` events in `AudioRecorder` and `StepsRecorder` were required by `IRecorder` and subscribed to, but never invoked. This PR adds try-catch blocks to invoke these events on exceptions, ensuring proper error propagation and consistent user feedback. The `LanguageChanged` event in `LanguageFields` is a virtual event intended for derived classes to invoke, so its warning is now suppressed with an explanatory comment.

---
<a href="https://cursor.com/background-agent?bcId=bc-45ff2630-b0b7-471f-95c0-08b8d2a0f361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45ff2630-b0b7-471f-95c0-08b8d2a0f361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

