### PR TITLE
Review build warnings and fix issues

### DIFF
--- a/src/Captura.Fakes/FakeRegionProvider.cs
+++ b/src/Captura.Fakes/FakeRegionProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 using System;
 using Captura.Video;
 
@@ -19,10 +19,6 @@ namespace Captura.Fakes
         public Rectangle SelectedRegion { get; set; }
 
         public IVideoItem VideoSource => new RegionItem(this, ServiceProvider.Get<IPlatformServices>());
-
-#pragma warning disable CS0067
-        public event Action SelectorHidden;
-#pragma warning restore CS0067
 
         public IntPtr Handle => IntPtr.Zero;
     }

--- a/src/Captura/Windows/OverlayWindow.xaml.cs
+++ b/src/Captura/Windows/OverlayWindow.xaml.cs
@@ -413,7 +413,7 @@ namespace Captura
             PlaceOverlays();
         }
 
-        async void UpdateBackground()
+        void UpdateBackground()
         {
             // Modern version doesn't have VideoViewModel on MainViewModel
             // Just capture a simple screenshot

--- a/src/Captura/Windows/RegionSelector.xaml.cs
+++ b/src/Captura/Windows/RegionSelector.xaml.cs
@@ -309,8 +309,6 @@ namespace Captura
         }
 
         #region IRegionProvider
-        public event Action SelectorHidden;
-
         public bool SelectorVisible
         {
             get => Visibility == Visibility.Visible;


### PR DESCRIPTION
Remove unused `SelectorHidden` event and `async` keyword from `UpdateBackground` method to resolve build warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-854c2e89-e5d8-4601-8b68-b037ce7a19c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-854c2e89-e5d8-4601-8b68-b037ce7a19c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

