### PR TITLE
Fix installer shortcut to osrStudio.exe

### DIFF
--- a/Inno.iss
+++ b/Inno.iss
@@ -4,7 +4,7 @@
 #define MyAppName "Captura"
 #define MyAppPublisher "Mathew Sachin"
 #define MyAppURL "https://MathewSachin.github.io/Captura"
-#define MyAppExeName "osrStudio.exe"
+#define MyAppExeName "OsrStudio.exe"
 
 [Setup]
 AppId={{C1670C5E-5042-4300-9491-6BFFF963823F}

--- a/Inno.iss
+++ b/Inno.iss
@@ -4,7 +4,7 @@
 #define MyAppName "Captura"
 #define MyAppPublisher "Mathew Sachin"
 #define MyAppURL "https://MathewSachin.github.io/Captura"
-#define MyAppExeName "captura.exe"
+#define MyAppExeName "osrStudio.exe"
 
 [Setup]
 AppId={{C1670C5E-5042-4300-9491-6BFFF963823F}


### PR DESCRIPTION
Fix classic release installer shortcuts by updating `MyAppExeName` to `osrStudio.exe`.

---
<a href="https://cursor.com/background-agent?bcId=bc-29d073df-9436-47ea-af46-eaefb04f99c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29d073df-9436-47ea-af46-eaefb04f99c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

